### PR TITLE
Separate agent login from home interface

### DIFF
--- a/public/agent/home.html
+++ b/public/agent/home.html
@@ -10,21 +10,15 @@
 <body class="bg-gray-50">
   <div class="max-w-6xl mx-auto grid md:grid-cols-[320px_1fr] gap-4 p-4">
     <aside class="bg-white border border-gray-200 rounded-xl p-4">
-      <h2 class="text-base font-semibold">Agent Login</h2>
-      <div id="loginPane" class="space-y-2 mt-2">
-        <input id="email" placeholder="Email" class="w-full rounded-md border-gray-300 px-3 py-2 text-sm focus:ring-brand-600 focus:border-brand-600"/>
-        <input id="password" type="password" placeholder="Password" class="w-full rounded-md border-gray-300 px-3 py-2 text-sm focus:ring-brand-600 focus:border-brand-600"/>
-        <select id="department" class="w-full rounded-md border-gray-300 px-3 py-2 text-sm focus:ring-brand-600 focus:border-brand-600"></select>
-        <button id="btnLogin" class="w-full rounded-md bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 text-sm">Login & Go Online</button>
-        <div id="loginMsg" class="text-sm text-red-600"></div>
-      </div>
-
-      <h3 class="mt-6 mb-2 font-semibold">Pending Chats</h3>
-      <div id="pending" class="rounded-lg border border-dashed border-gray-300 p-3 text-sm text-gray-600">Login first.</div>
+      <h3 class="mb-2 font-semibold">Pending Chats</h3>
+      <div id="pending" class="rounded-lg border border-dashed border-gray-300 p-3 text-sm text-gray-600">Loading...</div>
     </aside>
 
     <main class="bg-white border border-gray-200 rounded-xl flex flex-col overflow-hidden">
-      <header id="status" class="px-4 py-3 border-b border-gray-200 text-gray-700">Not connected</header>
+      <header class="flex items-center justify-between px-4 py-3 border-b border-gray-200 text-gray-700">
+        <div id="status">Not connected</div>
+        <button id="logoutBtn" class="rounded-md bg-red-600 hover:bg-red-700 text-white px-3 py-1.5 text-sm">Logout</button>
+      </header>
       <section class="flex-1 grid" style="grid-template-rows: 1fr auto;">
         <div id="messages" class="overflow-y-auto p-4 space-y-2 bg-white"></div>
         <div id="composer" class="bg-gray-50 border-t border-gray-200 p-3 flex flex-wrap items-center gap-2">

--- a/public/agent/js/agent.js
+++ b/public/agent/js/agent.js
@@ -1,12 +1,12 @@
 import { connectAgentSocket } from './socket.js';
 
-let token=null, socket=null, currentChatId=null;
+const token = localStorage.getItem('agentToken');
+const department = localStorage.getItem('agentDepartment');
+if(!token || !department){
+  location.href = 'login.html';
+}
 
-const emailEl = document.getElementById('email');
-const passwordEl = document.getElementById('password');
-const deptSel = document.getElementById('department');
-const btnLogin = document.getElementById('btnLogin');
-const loginMsg = document.getElementById('loginMsg');
+let socket=null, currentChatId=null;
 
 const statusHeader = document.getElementById('status');
 const pendingDiv = document.getElementById('pending');
@@ -16,83 +16,53 @@ const sendBtn = document.getElementById('sendBtn');
 const fileInput = document.getElementById('fileInput');
 const sendFileBtn = document.getElementById('sendFileBtn');
 const closeBtn = document.getElementById('closeBtn');
+const logoutBtn = document.getElementById('logoutBtn');
 
-// depts
-fetch('/api/departments').then(r=>r.json()).then(d=>{
-  const list=(d.departments&&d.departments.length)?d.departments:['Eye','Cardiology','Orthopedics','ENT','Neurology','General'];
-  list.forEach(dep=>{ const o=document.createElement('option'); o.value=o.textContent=dep; deptSel.appendChild(o); });
-});
-
-btnLogin.onclick = async ()=>{
-  loginMsg.textContent='';
-  try{
-    const res = await fetch('/api/agents/login',{
-      method:'POST', headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ email: emailEl.value.trim(), password: passwordEl.value })
-    });
-    const j = await res.json();
-    if(!res.ok || !j.token){ loginMsg.textContent=j.error||'Login failed'; return; }
-    token = j.token;
-
-    statusHeader.textContent='Logged in. Connecting…';
-    socket = connectAgentSocket(token, deptSel.value);
-
-    socket.on('agent:registered', ({ department })=>{
-      statusHeader.textContent = `Online in ${department}`;
-    });
-    socket.on('agent:pending_list', renderPending);
-    socket.on('agent:accept_failed', ({ reason })=> alert('Accept failed: '+reason));
-
-    socket.on('chat:assigned', ({ chatId })=>{
-      currentChatId = chatId;
-      toggleChatControls(true);
-      statusHeader.textContent='Chat active';
-      messagesDiv.innerHTML='';
-      socket.emit('chat:history_request', { chatId });
-    });
-
-    socket.on('chat:history', ({ chatId:id, items })=>{
-      if(id!==currentChatId) return;
-      for(const m of items){
-        if(m.url) addFileBubble('agent', m.url, m.name, m.agentName||'Agent', m.at);
-        else if(m.text) addTextBubble(m.from, m.text, m.agentName || (m.from==='patient'?'Patient':'Agent'), m.at);
-      }
-      messagesDiv.scrollTop = messagesDiv.scrollHeight;
-    });
-
-    socket.on('chat:message', (m)=>{
-      if(m.from==='agent') return;
-      addTextBubble('patient', m.text, 'Patient', m.at);
-    });
-    socket.on('chat:file', (m)=>{
-      const who = m.from==='agent'?'Agent':'Patient';
-      addFileBubble(m.from, m.url, m.name, who, m.at);
-    });
-    socket.on('chat:closed', ()=>{
-      toggleChatControls(false);
-      statusHeader.textContent='Chat closed';
-    });
-
-  }catch(e){ loginMsg.textContent='Network error'; }
+logoutBtn.onclick = ()=>{
+  localStorage.removeItem('agentToken');
+  localStorage.removeItem('agentDepartment');
+  if(socket) socket.disconnect();
+  location.href = 'login.html';
 };
 
-function renderPending(items){
-  pendingDiv.innerHTML = '';
-  if(!items.length){ pendingDiv.innerHTML = '<div class="text-gray-500">No pending chats</div>'; return; }
-  items.sort((a,b)=> new Date(a.createdAt) - new Date(b.createdAt));
-  for(const it of items){
-    const row = document.createElement('div');
-    row.className = 'flex items-center justify-between border border-gray-200 rounded-md p-3 mb-2';
-    row.innerHTML = `<div><div class="font-medium">${it.patientName || 'Patient'}</div>
-      <div class="text-xs text-gray-500">${new Date(it.createdAt).toLocaleString()}</div></div>`;
-    const btn = document.createElement('button');
-    btn.className = 'rounded-md bg-brand-600 hover:bg-brand-700 text-white px-3 py-1.5 text-sm';
-    btn.textContent = 'Accept';
-    btn.onclick = ()=> socket.emit('agent:accept', { chatId: it.id });
-    row.appendChild(btn);
-    pendingDiv.appendChild(row);
+statusHeader.textContent='Connecting…';
+socket = connectAgentSocket(token, department);
+
+socket.on('agent:registered', ({ department })=>{
+  statusHeader.textContent = `Online in ${department}`;
+});
+socket.on('agent:pending_list', renderPending);
+socket.on('agent:accept_failed', ({ reason })=> alert('Accept failed: '+reason));
+
+socket.on('chat:assigned', ({ chatId })=>{
+  currentChatId = chatId;
+  toggleChatControls(true);
+  statusHeader.textContent='Chat active';
+  messagesDiv.innerHTML='';
+  socket.emit('chat:history_request', { chatId });
+});
+
+socket.on('chat:history', ({ chatId:id, items })=>{
+  if(id!==currentChatId) return;
+  for(const m of items){
+    if(m.url) addFileBubble('agent', m.url, m.name, m.agentName||'Agent', m.at);
+    else if(m.text) addTextBubble(m.from, m.text, m.agentName || (m.from==='patient'?'Patient':'Agent'), m.at);
   }
-}
+  messagesDiv.scrollTop = messagesDiv.scrollHeight;
+});
+
+socket.on('chat:message', (m)=>{
+  if(m.from==='agent') return;
+  addTextBubble('patient', m.text, 'Patient', m.at);
+});
+socket.on('chat:file', (m)=>{
+  const who = m.from==='agent'?'Agent':'Patient';
+  addFileBubble(m.from, m.url, m.name, who, m.at);
+});
+socket.on('chat:closed', ()=>{
+  toggleChatControls(false);
+  statusHeader.textContent='Chat closed';
+});
 
 sendBtn.onclick = ()=>{
   const text = msgInput.value.trim();
@@ -122,6 +92,24 @@ closeBtn.onclick = ()=>{
   statusHeader.textContent='Chat closed';
 };
 
+function renderPending(items){
+  pendingDiv.innerHTML = '';
+  if(!items.length){ pendingDiv.innerHTML = '<div class="text-gray-500">No pending chats</div>'; return; }
+  items.sort((a,b)=> new Date(a.createdAt) - new Date(b.createdAt));
+  for(const it of items){
+    const row = document.createElement('div');
+    row.className = 'flex items-center justify-between border border-gray-200 rounded-md p-3 mb-2';
+    row.innerHTML = `<div><div class="font-medium">${it.patientName || 'Patient'}</div>
+      <div class="text-xs text-gray-500">${new Date(it.createdAt).toLocaleString()}</div></div>`;
+    const btn = document.createElement('button');
+    btn.className = 'rounded-md bg-brand-600 hover:bg-brand-700 text-white px-3 py-1.5 text-sm';
+    btn.textContent = 'Accept';
+    btn.onclick = ()=> socket.emit('agent:accept', { chatId: it.id });
+    row.appendChild(btn);
+    pendingDiv.appendChild(row);
+  }
+}
+
 function toggleChatControls(enabled){
   msgInput.disabled = !enabled; sendBtn.disabled = !enabled;
   fileInput.disabled = !enabled; sendFileBtn.disabled = !enabled;
@@ -133,15 +121,20 @@ function addTextBubble(from, text, who, at){
   wrap.className = 'w-full flex ' + (from==='agent'?'justify-start':'justify-end');
   const bub = document.createElement('div');
   bub.className = 'max-w-[70%] rounded-2xl px-3 py-2 text-sm shadow-sm ' + (from==='agent'?'bg-gray-100':'bg-brand-600 text-white');
-  bub.innerHTML = `<div class="opacity-70 text-[11px] mb-0.5">${new Date(at).toLocaleTimeString()} • ${who}</div>${(text||'').replace(/</g,'&lt;')}`;
+  bub.innerHTML = `<div class=\"opacity-70 text-[11px] mb-0.5\">${new Date(at).toLocaleTimeString()} • ${who}</div>${(text||'').replace(/</g,'&lt;')}`;
   wrap.appendChild(bub); messagesDiv.appendChild(wrap); messagesDiv.scrollTop=messagesDiv.scrollHeight;
 }
+
 function addFileBubble(from, url, name, who, at){
   const wrap = document.createElement('div');
   wrap.className = 'w-full flex ' + (from==='agent'?'justify-start':'justify-end');
-  wrap.innerHTML = `<div class="max-w-[70%] rounded-2xl px-3 py-2 text-sm shadow-sm ${from==='agent'?'bg-gray-100':'bg-brand-600 text-white'}">
-    <div class="opacity-70 text-[11px] mb-0.5">${new Date(at).toLocaleTimeString()} • ${who}</div>
-    <a class="underline" href="${url}" target="_blank">${name || 'file'}</a>
+  wrap.innerHTML = `<div class=\"max-w-[70%] rounded-2xl px-3 py-2 text-sm shadow-sm ${from==='agent'?'bg-gray-100':'bg-brand-600 text-white'}\">
+    <div class=\"opacity-70 text-[11px] mb-0.5\">${new Date(at).toLocaleTimeString()} • ${who}</div>
+    <a class=\"underline\" href=\"${url}\" target=\"_blank\">${name || 'file'}</a>
   </div>`;
   messagesDiv.appendChild(wrap); messagesDiv.scrollTop=messagesDiv.scrollHeight;
 }
+
+
+toggleChatControls(false);
+

--- a/public/agent/js/login.js
+++ b/public/agent/js/login.js
@@ -1,0 +1,28 @@
+const emailEl = document.getElementById('email');
+const passwordEl = document.getElementById('password');
+const deptSel = document.getElementById('department');
+const btnLogin = document.getElementById('btnLogin');
+const loginMsg = document.getElementById('loginMsg');
+
+// populate departments
+fetch('/api/departments').then(r=>r.json()).then(d=>{
+  const list = (d.departments && d.departments.length) ? d.departments : ['Eye','Cardiology','Orthopedics','ENT','Neurology','General'];
+  list.forEach(dep=>{ const o=document.createElement('option'); o.value=o.textContent=dep; deptSel.appendChild(o); });
+});
+
+btnLogin.onclick = async ()=>{
+  loginMsg.textContent = '';
+  try {
+    const res = await fetch('/api/agents/login', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ email: emailEl.value.trim(), password: passwordEl.value })
+    });
+    const j = await res.json();
+    if(!res.ok || !j.token){ loginMsg.textContent = j.error || 'Login failed'; return; }
+    localStorage.setItem('agentToken', j.token);
+    localStorage.setItem('agentDepartment', deptSel.value);
+    location.href = 'home.html';
+  } catch(e){
+    loginMsg.textContent = 'Network error';
+  }
+};

--- a/public/agent/login.html
+++ b/public/agent/login.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+  <title>Agent Login</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config={theme:{extend:{colors:{brand:{600:'#0aa356',700:'#0a8147'}}}}}</script>
+</head>
+<body class="bg-gray-50">
+  <div class="max-w-sm mx-auto p-4">
+    <div class="bg-white border border-gray-200 rounded-xl p-4 space-y-2">
+      <h2 class="text-base font-semibold">Agent Login</h2>
+      <input id="email" placeholder="Email" class="w-full rounded-md border-gray-300 px-3 py-2 text-sm focus:ring-brand-600 focus:border-brand-600"/>
+      <input id="password" type="password" placeholder="Password" class="w-full rounded-md border-gray-300 px-3 py-2 text-sm focus:ring-brand-600 focus:border-brand-600"/>
+      <select id="department" class="w-full rounded-md border-gray-300 px-3 py-2 text-sm focus:ring-brand-600 focus:border-brand-600"></select>
+      <button id="btnLogin" class="w-full rounded-md bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 text-sm">Login & Go Online</button>
+      <div id="loginMsg" class="text-sm text-red-600"></div>
+    </div>
+  </div>
+
+  <script src="/agent/js/login.js" type="module"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Move login form into new `public/agent/login.html`
- Rename original `agent.html` to `home.html` and add logout control
- Split login logic into `login.js`; use stored JWT for socket connection in updated `agent.js`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5e5d16b248331968edf20cae03f36