### PR TITLE
Fix department dropdown showing objects

### DIFF
--- a/public/admin/js/dashboard.js
+++ b/public/admin/js/dashboard.js
@@ -39,10 +39,13 @@ async function loadDepartments() {
     const j = await res.json();
     const sel = document.getElementById('inviteDept');
     sel.innerHTML = '<option value="">Select department</option>';
-    const list = (j.departments && j.departments.length) ? j.departments
+    const list = (j.departments && j.departments.length)
+      ? j.departments.map(d => d.name)
       : ['Eye','Cardiology','Orthopedics','ENT','Neurology','General'];
-    list.forEach(d => {
-      const opt = document.createElement('option'); opt.value = d; opt.textContent = d;
+    list.forEach(name => {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
       sel.appendChild(opt);
     });
   } catch (e) {

--- a/public/agent/js/login.js
+++ b/public/agent/js/login.js
@@ -6,8 +6,15 @@ const loginMsg = document.getElementById('loginMsg');
 
 // populate departments
 fetch('/api/departments').then(r=>r.json()).then(d=>{
-  const list = (d.departments && d.departments.length) ? d.departments : ['Eye','Cardiology','Orthopedics','ENT','Neurology','General'];
-  list.forEach(dep=>{ const o=document.createElement('option'); o.value=o.textContent=dep; deptSel.appendChild(o); });
+  const list = (d.departments && d.departments.length)
+    ? d.departments.map(dep => dep.name)
+    : ['Eye','Cardiology','Orthopedics','ENT','Neurology','General'];
+  list.forEach(dep => {
+    const o = document.createElement('option');
+    o.value = dep;
+    o.textContent = dep;
+    deptSel.appendChild(o);
+  });
 });
 
 btnLogin.onclick = async ()=>{


### PR DESCRIPTION
## Summary
- Map department API data to names on agent login
- Show department names in admin invite dropdown

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68a9cd87d72c83319f6d44523e4e7e64