### PR TITLE
feat(agent): lock department on login

### DIFF
--- a/public/agent/js/login.js
+++ b/public/agent/js/login.js
@@ -1,20 +1,20 @@
 const emailEl = document.getElementById('email');
 const passwordEl = document.getElementById('password');
-const deptSel = document.getElementById('department');
+const deptInput = document.getElementById('department');
 const btnLogin = document.getElementById('btnLogin');
 const loginMsg = document.getElementById('loginMsg');
 
-// populate departments
-fetch('/api/departments').then(r=>r.json()).then(d=>{
-  const list = (d.departments && d.departments.length)
-    ? d.departments.map(dep => dep.name)
-    : ['Eye','Cardiology','Orthopedics','ENT','Neurology','General'];
-  list.forEach(dep => {
-    const o = document.createElement('option');
-    o.value = dep;
-    o.textContent = dep;
-    deptSel.appendChild(o);
-  });
+emailEl.addEventListener('blur', async () => {
+  const email = emailEl.value.trim();
+  deptInput.value = '';
+  if (!email) return;
+  try {
+    const res = await fetch(`/api/agents/department?email=${encodeURIComponent(email)}`);
+    const j = await res.json();
+    if (res.ok && j.department) deptInput.value = j.department;
+  } catch (e) {
+    console.error('department lookup failed', e);
+  }
 });
 
 btnLogin.onclick = async ()=>{
@@ -27,7 +27,7 @@ btnLogin.onclick = async ()=>{
     const j = await res.json();
     if(!res.ok || !j.token){ loginMsg.textContent = j.error || 'Login failed'; return; }
     localStorage.setItem('agentToken', j.token);
-    localStorage.setItem('agentDepartment', deptSel.value);
+    localStorage.setItem('agentDepartment', j.department);
     location.href = 'home.html';
   } catch(e){
     loginMsg.textContent = 'Network error';

--- a/public/agent/login.html
+++ b/public/agent/login.html
@@ -14,7 +14,7 @@
       <h2 class="text-base font-semibold">Agent Login</h2>
       <input id="email" placeholder="Email" class="w-full rounded-md border-gray-300 px-3 py-2 text-sm focus:ring-brand-600 focus:border-brand-600"/>
       <input id="password" type="password" placeholder="Password" class="w-full rounded-md border-gray-300 px-3 py-2 text-sm focus:ring-brand-600 focus:border-brand-600"/>
-      <select id="department" class="w-full rounded-md border-gray-300 px-3 py-2 text-sm focus:ring-brand-600 focus:border-brand-600"></select>
+      <input id="department" placeholder="Department" readonly class="w-full rounded-md border-gray-300 px-3 py-2 text-sm bg-gray-100"/>
       <button id="btnLogin" class="w-full rounded-md bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 text-sm">Login & Go Online</button>
       <div id="loginMsg" class="text-sm text-red-600"></div>
     </div>

--- a/src/routes/agent.js
+++ b/src/routes/agent.js
@@ -51,6 +51,19 @@ export default function AgentRoutes(pool) {
     } catch (e) { console.error(e); res.status(500).json({ error: 'Server error' }); }
   });
 
+  router.get('/api/agents/department', async (req, res) => {
+    try {
+      const { email } = req.query;
+      if (!email) return res.status(400).json({ error: 'Email required' });
+      const result = await pool.query('SELECT department FROM agents WHERE email=$1 LIMIT 1', [String(email).toLowerCase()]);
+      if (!result.rowCount) return res.status(404).json({ error: 'Not found' });
+      res.json({ department: result.rows[0].department });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Server error' });
+    }
+  });
+
 // Example Express route
 router.get('/api/faqs/top', async (req, res) => {
   const faqs = await pool.query('SELECT id, question FROM faq_entries WHERE parent_id IS NULL ORDER BY id');


### PR DESCRIPTION
## Summary
- Show agent department as read-only on login screen
- Store department from server response instead of dropdown selection
- Add API endpoint to look up department by agent email

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9ea05adf083319c4a1052955cab8b