### PR TITLE
fix: defer agent notification until escalation

### DIFF
--- a/src/sockets/index.js
+++ b/src/sockets/index.js
@@ -108,8 +108,6 @@ socket.on('patient:new_conversation', async ({ patientName }) => {
       suggestions: [] // Optional: add default FAQs if needed
     });
 
-    // Notify agents that a new chat without department is pending
-    await broadcastPending();
 
   } catch (e) {
     console.error('[Error in patient:new_conversation]', e);


### PR DESCRIPTION
## Summary
- Avoid notifying agents about a conversation as soon as it starts
- Agents now only see pending chats once escalation criteria are met

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa037b616c8331b1fbaa9abd4c1a75