### PR TITLE
fix: share pending chats to all agents and keep list after refresh

### DIFF
--- a/public/agent/js/agent.js
+++ b/public/agent/js/agent.js
@@ -9,6 +9,11 @@ if(!token || !department){
 let socket=null, currentChatId=null;
 let departmentInfo=[];
 
+const cachedPending = localStorage.getItem('pendingChats');
+if (cachedPending) {
+  renderPending(JSON.parse(cachedPending));
+}
+
 const statusHeader = document.getElementById('status');
 const pendingDiv = document.getElementById('pending');
 const messagesDiv = document.getElementById('messages');
@@ -23,6 +28,7 @@ const logoutBtn = document.getElementById('logoutBtn');
 logoutBtn.onclick = ()=>{
   localStorage.removeItem('agentToken');
   localStorage.removeItem('agentDepartment');
+  localStorage.removeItem('pendingChats');
   if(socket) socket.disconnect();
   location.href = 'login.html';
 };
@@ -36,7 +42,10 @@ socket.on('agent:registered', ({ department })=>{
 socket.on('agent:department_counts', (rows)=>{
   departmentInfo = rows || [];
 });
-socket.on('agent:pending_list', renderPending);
+socket.on('agent:pending_list', (items)=>{
+  localStorage.setItem('pendingChats', JSON.stringify(items));
+  renderPending(items);
+});
 socket.on('agent:accept_failed', ({ reason })=> alert('Accept failed: '+reason));
 socket.on('agent:forward_failed', ({ reason })=> alert('Forward failed: '+reason));
 socket.on('agent:forwarded', ({ chatId:id })=>{

--- a/src/sockets/index.js
+++ b/src/sockets/index.js
@@ -61,12 +61,10 @@ export function socketHandlers(io, pool) {
     const items = await getPendingList(department);
     if (department) {
       const room = `dept_${department}`;
-      const sockets = await io.in(room).fetchSockets();
-      if (sockets.length) {
-        io.to(room).emit('agent:pending_list', items);
-      } else {
-        io.to('agents').emit('agent:pending_list', items);
-      }
+      // Notify agents in the specific department
+      io.to(room).emit('agent:pending_list', items);
+      // Also notify all other agents to keep global lists in sync
+      io.to('agents').except(room).emit('agent:pending_list', items);
     } else {
       io.to('agents').emit('agent:pending_list', items);
     }
@@ -350,12 +348,10 @@ export function makeBroadcastHelpers(io, pool) {
     if (department) {
       console.log(`[broadcastPending] Sending pending list to dept_${department}`);
       const room = `dept_${department}`;
-      const sockets = await io.in(room).fetchSockets();
-      if (sockets.length) {
-        io.to(room).emit('agent:pending_list', items);
-      } else {
-        io.to('agents').emit('agent:pending_list', items);
-      }
+      // Notify agents in the department
+      io.to(room).emit('agent:pending_list', items);
+      // And inform all other agents to keep them in sync
+      io.to('agents').except(room).emit('agent:pending_list', items);
     } else {
       console.log('[broadcastPending] Sending pending list to all agents');
       io.to('agents').emit('agent:pending_list', items);


### PR DESCRIPTION
## Summary
- broadcast pending chat updates to all agents and exclude duplicates
- cache pending chat list in localStorage so agents keep notifications after refresh

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa058451348331b28debbc680d2c5f