### PR TITLE
chore: add debug logs for agent notifications

### DIFF
--- a/src/services/escalation.js
+++ b/src/services/escalation.js
@@ -53,6 +53,9 @@ export async function escalateToHuman({
   }
 
   // 3) Notify agents in department that a new pending chat is available
+  console.log(
+    `[escalateToHuman] chatId=${chatId} department=${department} notifying agents`
+  );
   await broadcastPending(department);
 
   // Optionally, join a socket room if you have a user socket here (not in this service)


### PR DESCRIPTION
## Summary
- add detailed logs for pending chat broadcasts
- log agent socket rooms on registration
- trace escalations when notifying agents

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa51e7adf48331ac781e2746fc9166