### PR TITLE
Clear department cookie on new chats

### DIFF
--- a/public/widget/js/widget.js
+++ b/public/widget/js/widget.js
@@ -3,6 +3,10 @@ import { connectWidgetSocket } from './socket.js';
 const socket = connectWidgetSocket();
 let chatId = null;
 
+function clearDepartmentCookie() {
+  document.cookie = 'department=; Max-Age=0; path=/';
+}
+
 // DOM elements
 const deptSel = document.getElementById('department');
 const startChatBtn = document.getElementById('startChatBtn');
@@ -28,6 +32,7 @@ startChatBtn.onclick = () => {
   }
 
   console.log('[Chat] Starting new conversation as:', patientName);
+  clearDepartmentCookie();
   socket.emit('patient:new_conversation', { patientName });
 
   // UI updates


### PR DESCRIPTION
## Summary
- Clear department cookie before starting a new patient conversation to avoid routing to stale departments

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa5f6bf9188331a1b30f79143c09af