### PR TITLE
Add theme selector to shared banner

### DIFF
--- a/public/banner.html
+++ b/public/banner.html
@@ -1,4 +1,18 @@
-<header class="bg-brand-600 text-white px-4 py-3 flex items-center gap-3 shadow">
-  <div class="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center" aria-hidden="true">🏥</div>
-  <h1 class="text-lg font-semibold tracking-tight">ABC Hospital</h1>
+<header id="siteBanner" data-banner-root class="bg-brand-600 text-white shadow">
+  <div class="max-w-6xl mx-auto flex flex-wrap items-center gap-3 px-4 py-3">
+    <div class="flex items-center gap-3 min-w-[200px]">
+      <div class="w-9 h-9 rounded-full bg-white/15 flex items-center justify-center text-lg" aria-hidden="true">🏥</div>
+      <div>
+        <div class="text-lg font-semibold leading-tight">ABC Hospital</div>
+        <div class="text-white/80 text-sm -mt-0.5">24/7 Support Desk</div>
+      </div>
+    </div>
+    <div class="flex items-center gap-3 text-sm ml-auto flex-wrap justify-end" data-theme-toolbar>
+      <span class="font-medium text-white/80">Theme</span>
+      <div class="flex items-center gap-2" data-theme-swatches></div>
+      <label class="sr-only" for="themeSelect">Choose a theme</label>
+      <select id="themeSelect" data-theme-select class="bg-white/95 text-gray-900 text-sm rounded-md border border-white/40 px-2 py-1 focus:outline-none focus:ring-2 focus:ring-white focus:border-white/60 min-w-[150px]">
+      </select>
+    </div>
+  </div>
 </header>

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -1,0 +1,77 @@
+:root {
+  --brand-50: #eefdf4;
+  --brand-100: #d7f8e4;
+  --brand-200: #aaf0c7;
+  --brand-300: #75e4a6;
+  --brand-400: #3bd77f;
+  --brand-500: #12c969;
+  --brand-600: #0aa356;
+  --brand-700: #0a8147;
+  --brand-800: #0a653b;
+  --brand-900: #0a5433;
+}
+
+/* Background utilities */
+.bg-brand-600 {
+  background-color: var(--brand-600) !important;
+}
+
+.hover\:bg-brand-700:hover {
+  background-color: var(--brand-700) !important;
+}
+
+/* Border utilities */
+.border-brand-500,
+.focus\:border-brand-500:focus {
+  border-color: var(--brand-500) !important;
+}
+
+.border-brand-600,
+.focus\:border-brand-600:focus,
+.hover\:border-brand-600:hover {
+  border-color: var(--brand-600) !important;
+}
+
+/* Ring utilities */
+.focus\:ring-brand-500:focus {
+  --tw-ring-color: var(--brand-500) !important;
+  --tw-ring-opacity: 1 !important;
+}
+
+.focus\:ring-brand-600:focus {
+  --tw-ring-color: var(--brand-600) !important;
+  --tw-ring-opacity: 1 !important;
+}
+
+/* Text utilities */
+.text-brand-600 {
+  color: var(--brand-600) !important;
+}
+
+/* Theme swatches */
+.theme-swatch {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-swatch:hover {
+  transform: scale(1.05);
+}
+
+.theme-swatch.is-active {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.85);
+  transform: scale(1.12);
+}
+
+.theme-swatch:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 2px;
+}

--- a/public/js/banner.js
+++ b/public/js/banner.js
@@ -1,10 +1,173 @@
+const THEME_STORAGE_KEY = 'hospital-theme';
+const THEMES = [
+  {
+    id: 'emerald',
+    name: 'Emerald',
+    palette: {
+      50: '#eefdf4',
+      100: '#d7f8e4',
+      200: '#aaf0c7',
+      300: '#75e4a6',
+      400: '#3bd77f',
+      500: '#12c969',
+      600: '#0aa356',
+      700: '#0a8147',
+      800: '#0a653b',
+      900: '#0a5433'
+    }
+  },
+  {
+    id: 'ocean',
+    name: 'Ocean',
+    palette: {
+      50: '#eff6ff',
+      100: '#dbeafe',
+      200: '#bfdbfe',
+      300: '#93c5fd',
+      400: '#60a5fa',
+      500: '#3b82f6',
+      600: '#2563eb',
+      700: '#1d4ed8',
+      800: '#1e40af',
+      900: '#1e3a8a'
+    }
+  },
+  {
+    id: 'sunset',
+    name: 'Sunset',
+    palette: {
+      50: '#fff7ed',
+      100: '#ffedd5',
+      200: '#fed7aa',
+      300: '#fdba74',
+      400: '#fb923c',
+      500: '#f97316',
+      600: '#ea580c',
+      700: '#c2410c',
+      800: '#9a3412',
+      900: '#7c2d12'
+    }
+  },
+  {
+    id: 'violet',
+    name: 'Violet',
+    palette: {
+      50: '#f5f3ff',
+      100: '#ede9fe',
+      200: '#ddd6fe',
+      300: '#c4b5fd',
+      400: '#a78bfa',
+      500: '#8b5cf6',
+      600: '#7c3aed',
+      700: '#6d28d9',
+      800: '#5b21b6',
+      900: '#4c1d95'
+    }
+  }
+];
+
 document.addEventListener('DOMContentLoaded', async () => {
   const placeholder = document.getElementById('banner');
   if (!placeholder) return;
+
   try {
     const res = await fetch('/banner.html');
-    placeholder.outerHTML = await res.text();
+    const html = await res.text();
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = html.trim();
+    const bannerEl = wrapper.firstElementChild;
+    placeholder.replaceWith(bannerEl);
+
+    ensureThemeStylesheet();
+    initializeThemeControls(bannerEl);
   } catch (err) {
     console.error('Failed to load banner', err);
   }
 });
+
+function ensureThemeStylesheet() {
+  if (document.getElementById('themeStyles')) return;
+  const link = document.createElement('link');
+  link.id = 'themeStyles';
+  link.rel = 'stylesheet';
+  link.href = '/css/theme.css';
+  document.head.appendChild(link);
+}
+
+function initializeThemeControls(bannerEl) {
+  const select = bannerEl.querySelector('[data-theme-select]');
+  const swatchWrap = bannerEl.querySelector('[data-theme-swatches]');
+  const current = getStoredTheme();
+
+  if (select) {
+    select.innerHTML = THEMES.map(t => `<option value="${t.id}">${t.name}</option>`).join('');
+    select.value = current;
+    select.addEventListener('change', (event) => {
+      setTheme(event.target.value, bannerEl);
+    });
+  }
+
+  if (swatchWrap) {
+    swatchWrap.innerHTML = '';
+    THEMES.forEach(theme => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.dataset.themeId = theme.id;
+      btn.setAttribute('aria-label', `${theme.name} theme`);
+      btn.className = 'theme-swatch';
+      btn.style.backgroundColor = theme.palette[600];
+      btn.addEventListener('click', () => {
+        setTheme(theme.id, bannerEl);
+      });
+      swatchWrap.appendChild(btn);
+    });
+  }
+
+  setTheme(current, bannerEl);
+}
+
+function setTheme(themeId, bannerEl) {
+  const theme = THEMES.find(t => t.id === themeId) || THEMES[0];
+  const root = document.documentElement;
+
+  Object.entries(theme.palette).forEach(([shade, value]) => {
+    root.style.setProperty(`--brand-${shade}`, value);
+  });
+
+  root.setAttribute('data-theme', theme.id);
+  rememberTheme(theme.id);
+
+  const select = bannerEl.querySelector('[data-theme-select]');
+  if (select && select.value !== theme.id) {
+    select.value = theme.id;
+  }
+
+  updateActiveSwatches(bannerEl, theme.id);
+}
+
+function updateActiveSwatches(bannerEl, activeId) {
+  const swatches = bannerEl.querySelectorAll('[data-theme-id]');
+  swatches.forEach((btn) => {
+    const isActive = btn.dataset.themeId === activeId;
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    btn.classList.toggle('is-active', isActive);
+  });
+}
+
+function getStoredTheme() {
+  try {
+    const saved = localStorage.getItem(THEME_STORAGE_KEY);
+    if (THEMES.some(t => t.id === saved)) return saved;
+  } catch (err) {
+    console.warn('Theme storage unavailable', err);
+  }
+  return THEMES[0].id;
+}
+
+function rememberTheme(themeId) {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, themeId);
+  } catch (err) {
+    console.warn('Theme storage unavailable', err);
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the shared banner to surface a theme selector that is available on every page
- add client-side logic to apply different color palettes and persist the selected theme
- introduce CSS overrides so Tailwind brand utilities follow the active theme and style the swatches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf68b8d6fc83319be697a770ec8ddd